### PR TITLE
Adjust net vertical boundaries for balanced gameplay

### DIFF
--- a/script.js
+++ b/script.js
@@ -1088,8 +1088,13 @@ function gameLoop() {
     checkFlowers();
 
     nets.forEach(n => {
+      // Use actual rendered height (includes CSS transform scale) for bounds
+      const netHeight = n.el.getBoundingClientRect().height;
       n.y += n.speedY * n.dir;
-      if (n.y < 50 || n.y > window.innerHeight - 130) n.dir *= -1;
+      const minY = 5;
+      const maxY = Math.max(minY, window.innerHeight - netHeight - 5);
+      if (n.y < minY) { n.y = minY; n.dir *= -1; }
+      else if (n.y > maxY) { n.y = maxY; n.dir *= -1; }
       n.el.style.top = `${n.y}px`;
 
       const b = butterfly.getBoundingClientRect();


### PR DESCRIPTION
Adjust net vertical movement bounds to use dynamic heights, allowing them to travel closer to the screen edges and eliminate safety zones.

---
<a href="https://cursor.com/background-agent?bcId=bc-85017378-cc25-4d3c-8cf9-67cbe117e1b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85017378-cc25-4d3c-8cf9-67cbe117e1b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

